### PR TITLE
resolve import bug at `homepagetitle`

### DIFF
--- a/src/lib/components/3-Organism/HomepageTitle.svelte
+++ b/src/lib/components/3-Organism/HomepageTitle.svelte
@@ -6,9 +6,8 @@
   import { onMount } from "svelte";
 
   onMount(async () => {
-    const module = await import ('gsap')
-    const gsap = module.gsap;
-    const SplitText = (await import('gsap/SplitText')).SplitText;
+    const { gsap } = await import("gsap");
+    const { SplitText } = await import("gsap/SplitText");
 
     gsap.registerPlugin(SplitText);
 


### PR DESCRIPTION
# Description
Please include a summary of the changes and the related issue(s).  
Please include relevant motivation and context, with a screenshot if necessary.  
Please include a link to the live site, where the change is implemented.  

## Fixes issue
- issue #65 

## Type of change

There was a SSR import error at Vercel where there was no async function for [`HomepageTitle.svelte`](https://github.com/SamaraFellaDina/SamaraFellaDina/blob/3909c8dcad7518b491b0ee926c06ba905d6e82da/src/lib/components/3-Organism/HomepageTitle.svelte). didn't load the homepage and showed an error.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] The code is accessible
- [ ] The code is performant
- [ ] The code is responsive
- [ ] I have written meaningful commit messages
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README and/or Wiki)



